### PR TITLE
Get group OSCORE roll over functionality in place

### DIFF
--- a/CoAP.Example/CoAP.Client/ExampleClient.cs
+++ b/CoAP.Example/CoAP.Client/ExampleClient.cs
@@ -264,6 +264,7 @@ namespace Com.AugustCellars.CoAP.Examples
         {
             if (fileName == null) fileName = "ServerKeys.cbor";
             KeySet keys = new KeySet();
+            SecurityContextSet newSet = new SecurityContextSet();
 
             FileStream fs = new FileStream(fileName, FileMode.Open);
             using (BinaryReader reader = new BinaryReader(fs)) {
@@ -281,7 +282,7 @@ namespace Com.AugustCellars.CoAP.Examples
                                 key[CBORObject.FromObject("RecipID")].GetByteString(),
                                 key[CBORObject.FromObject("SenderID")].GetByteString(), null,
                                 key[CoseKeyKeys.Algorithm]);
-                            SecurityContextSet.AllContexts.Add(ctx);
+                            newSet.Add(ctx);
                             break;
                         }
                         else if (usage == "oscoap-group") {
@@ -292,7 +293,7 @@ namespace Com.AugustCellars.CoAP.Examples
                             foreach (CBORObject recipient in key[CBORObject.FromObject("recipients")].Values) {
                                 ctx.AddRecipient(recipient[CBORObject.FromObject("RecipID")].GetByteString(), new OneKey( recipient[CBORObject.FromObject("sign")]));
                             }
-                            SecurityContextSet.AllContexts.Add(ctx);
+                            newSet.Add(ctx);
                         }
                     }
 
@@ -304,7 +305,7 @@ namespace Com.AugustCellars.CoAP.Examples
             }
 
             //
-            return SecurityContextSet.AllContexts;
+            return newSet;
 
         }
     }

--- a/CoAP.NET/CoAP.Std10.csproj
+++ b/CoAP.NET/CoAP.Std10.csproj
@@ -25,6 +25,8 @@ It is intented primarily for research and verification work.
 1.6
   - Use cache key fields for matching blockwise transfers.
   - Some corrections for blockwise transfers over TCP
+  - Put in events to deal with OSCORE declared errors - IV exhaustion and unknown groups among others
+  - Move the global OSCORE security contexts to be server specific
 1.5
   - Update to use CBOR package 4.0.0 due to a security bug found.
 1.4
@@ -192,6 +194,7 @@ It is intented primarily for research and verification work.
     <Compile Include="OSCOAP\HKDF.cs" />
     <Compile Include="OSCOAP\OscoapLayer.cs" />
     <Compile Include="OSCOAP\OscoapOption.cs" />
+    <Compile Include="OSCOAP\OscoreEvent.cs" />
     <Compile Include="OSCOAP\SecureBlockwiseLayer.cs" />
     <Compile Include="OSCOAP\SecurityContext.cs" />
     <Compile Include="OSCOAP\SecurityContextSet.cs" />

--- a/CoAP.NET/DTLS/DTLSClientEndPoint.cs
+++ b/CoAP.NET/DTLS/DTLSClientEndPoint.cs
@@ -126,8 +126,8 @@ namespace Com.AugustCellars.CoAP.DTLS
 
         public KeySet CwtTrustKeySet
         {
-            get { return ((DTLSClientChannel) _channel).CwtTrustKeySet; }
-            set { ((DTLSClientChannel) _channel).CwtTrustKeySet = value; }
+            get { return ((DTLSClientChannel) dataChannel).CwtTrustKeySet; }
+            set { ((DTLSClientChannel) dataChannel).CwtTrustKeySet = value; }
         }
     }
 }

--- a/CoAP.NET/Net/Exchange.cs
+++ b/CoAP.NET/Net/Exchange.cs
@@ -105,7 +105,7 @@ namespace Com.AugustCellars.CoAP.Net
         /// Gets or sets the status of the security blockwise transfer of the request,
         /// or null in case of a normal transfer,
         /// </summary>
-        public BlockwiseStatus OSCOAP_RequestBlockStatus { get; set; }
+        public BlockwiseStatus OscoreRequestBlockStatus { get; set; }
 
         /// <summary>
         /// Gets or sets the status of the security blockwise transfer of the response,
@@ -284,7 +284,7 @@ namespace Com.AugustCellars.CoAP.Net
                     return false;
                 }
 
-                return _id == other._id && object.Equals(_endpoint, other._endpoint); // && (_session == other._session);
+                return _id == other._id && Equals(_endpoint, other._endpoint); // && (_session == other._session);
             }
 
             /// <inheritdoc/>

--- a/CoAP.NET/Net/IEndPoint.cs
+++ b/CoAP.NET/Net/IEndPoint.cs
@@ -11,7 +11,7 @@
 
 using System;
 using System.Net;
-using System.Reflection;
+using Com.AugustCellars.CoAP.OSCOAP;
 
 namespace Com.AugustCellars.CoAP.Net
 {
@@ -37,6 +37,10 @@ namespace Com.AugustCellars.CoAP.Net
         /// Gets or sets the message deliverer.
         /// </summary>
         IMessageDeliverer MessageDeliverer { get; set; }
+        /// <summary>
+        /// Gets/sets the OSCORE contexts
+        /// </summary>
+        SecurityContextSet SecurityContexts { get; set; }
         /// <summary>
         /// Gets the outbox.
         /// </summary>

--- a/CoAP.NET/OSCOAP/OscoreEvent.cs
+++ b/CoAP.NET/OSCOAP/OscoreEvent.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Com.AugustCellars.COSE;
+
+namespace Com.AugustCellars.CoAP.OSCOAP
+{
+    public class OscoreEvent
+    {
+        public enum EventCode
+        {
+            UnknownGroupIdentifier = 1,
+            UnknownKeyIdentifier = 2,
+            UnknownPublicKey = 3,
+            PivExhaustion = 4,
+            HitZoneMoved = 5,
+            SenderIvSave = 6
+        }
+
+        public EventCode Code { get; }
+        public byte[] GroupIdentifier { get; }
+        public byte[] KeyIdentifier { get; }
+        public SecurityContext SecurityContext { get; set; }
+        public SecurityContext.EntityContext RecipientContext { get; set; }
+
+        public OscoreEvent(EventCode code, byte[] groupIdentifier, byte[] keyIdentifier, SecurityContext context, SecurityContext.EntityContext recipient)
+        {
+            Code = code;
+            GroupIdentifier = groupIdentifier;
+            KeyIdentifier = keyIdentifier;
+            SecurityContext = context;
+            RecipientContext = recipient;
+        }
+    }
+}

--- a/CoAP.NET/OSCOAP/SecureBlockwiseLayer.cs
+++ b/CoAP.NET/OSCOAP/SecureBlockwiseLayer.cs
@@ -73,7 +73,7 @@ namespace Com.AugustCellars.CoAP.OSCOAP
                     log.Debug("Request payload " + request.PayloadSize + "/" + _maxMessageSize + " requires Blockwise.");
                 BlockwiseStatus status = FindRequestBlockStatus(exchange, request);
                 Request block = GetNextRequestBlock(request, status);
-                exchange.OSCOAP_RequestBlockStatus = status;
+                exchange.OscoreRequestBlockStatus = status;
                 exchange.CurrentRequest = block;
                 base.SendRequest(nextLayer, exchange, block);
             }
@@ -105,7 +105,7 @@ namespace Com.AugustCellars.CoAP.OSCOAP
                     if (log.IsDebugEnabled)
                         log.Debug("Block1 num is 0, the client has restarted the blockwise transfer. Reset status.");
                     status = new BlockwiseStatus(request.ContentType);
-                    exchange.OSCOAP_RequestBlockStatus = status;
+                    exchange.OscoreRequestBlockStatus = status;
                 }
 
                 if (block1.NUM == status.CurrentNUM)
@@ -306,7 +306,7 @@ namespace Com.AugustCellars.CoAP.OSCOAP
                 if (log.IsDebugEnabled)
                     log.Debug("Response acknowledges block " + block1);
 
-                BlockwiseStatus status = exchange.OSCOAP_RequestBlockStatus;
+                BlockwiseStatus status = exchange.OscoreRequestBlockStatus;
                 if (!status.Complete)
                 {
                     // TODO: the response code should be CONTINUE. Otherwise deliver
@@ -451,12 +451,12 @@ namespace Com.AugustCellars.CoAP.OSCOAP
         /// </summary>
         private BlockwiseStatus FindRequestBlockStatus(Exchange exchange, Request request)
         {
-            BlockwiseStatus status = exchange.OSCOAP_RequestBlockStatus;
+            BlockwiseStatus status = exchange.OscoreRequestBlockStatus;
             if (status == null)
             {
                 status = new BlockwiseStatus(request.ContentType);
                 status.CurrentSZX = BlockOption.EncodeSZX(_defaultBlockSize);
-                exchange.OSCOAP_RequestBlockStatus = status;
+                exchange.OscoreRequestBlockStatus = status;
                 if (log.IsDebugEnabled)
                     log.Debug("There is no assembler status yet. Create and set new Block1 status: " + status);
             }

--- a/CoAP.NET/OSCOAP/SecurityContextSet.cs
+++ b/CoAP.NET/OSCOAP/SecurityContextSet.cs
@@ -1,22 +1,18 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace Com.AugustCellars.CoAP.OSCOAP
 {
     /// <summary>
     /// Collection of OSCOAP security contexts
     /// </summary>
-    public class SecurityContextSet
+    public class SecurityContextSet : IEnumerable<SecurityContext>
     {
-        /// <summary>
-        /// Collection of all OSCOAP security contexts on the system.
-        /// </summary>
- 
-        public static SecurityContextSet AllContexts = new SecurityContextSet();
-
         /// <summary>
         /// Get the count of all security contexts.
         /// </summary>
-        public int Count { get => All.Count;}
+        public int Count => All.Count;
 
         /// <summary>
         /// Add a new context to the set
@@ -27,8 +23,15 @@ namespace Com.AugustCellars.CoAP.OSCOAP
             All.Add(ctx);
         }
 
+        public void Add(SecurityContextSet set)
+        {
+            foreach (SecurityContext c in set) {
+                All.Add(c);
+            }
+        }
+
         /// <summary>
-        /// Secuirty contexts for the object
+        /// Security contexts for the object
         /// </summary>
         public List<SecurityContext> All { get; } = new List<SecurityContext>();
 
@@ -43,10 +46,13 @@ namespace Com.AugustCellars.CoAP.OSCOAP
             foreach (SecurityContext ctx in All) {
                 if (ctx.Recipient != null &&  kid.Length == ctx.Recipient.Id.Length) {
                     bool match = true;
-                    for (int i=0; i<kid.Length;i++) if (kid[i] != ctx.Recipient.Id[i]) {
+                    for (int i=0; i<kid.Length;i++) {
+                        if (kid[i] != ctx.Recipient.Id[i]) {
                             match = false;
                             break;
                         }
+                    }
+
                     if (match) contexts.Add(ctx);
                 }
             }
@@ -74,6 +80,25 @@ namespace Com.AugustCellars.CoAP.OSCOAP
                 }
             }
             return contexts;
+        }
+
+
+        public event EventHandler<OscoreEvent> OscoreEvents;
+
+        public void OnEvent(OscoreEvent e)
+        {
+            EventHandler<OscoreEvent> eventHandler = OscoreEvents;
+            eventHandler?.Invoke(null, e);
+        }
+
+        public IEnumerator<SecurityContext> GetEnumerator()
+        {
+            return All.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return All.GetEnumerator();
         }
     }
 }

--- a/CoAP.NET/Server/CoapServer.cs
+++ b/CoAP.NET/Server/CoapServer.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Net;
 using Com.AugustCellars.CoAP.Log;
 using Com.AugustCellars.CoAP.Net;
+using Com.AugustCellars.CoAP.OSCOAP;
 using Com.AugustCellars.CoAP.Server.Resources;
 
 namespace Com.AugustCellars.CoAP.Server
@@ -28,6 +29,8 @@ namespace Com.AugustCellars.CoAP.Server
         private readonly List<IEndPoint> _endpoints = new List<IEndPoint>();
         private readonly System.Net.EndPoint _endPointSupplied;
         private IMessageDeliverer _deliverer;
+
+        public SecurityContextSet SecurityContexts { get; } = new SecurityContextSet();
 
         /// <summary>
         /// Constructs a server with default configuration.
@@ -141,6 +144,7 @@ namespace Com.AugustCellars.CoAP.Server
         public void AddEndPoint(IEndPoint endpoint)
         {
             endpoint.MessageDeliverer = _deliverer;
+            endpoint.SecurityContexts = SecurityContexts;
             _endpoints.Add(endpoint);
         }
 
@@ -310,14 +314,13 @@ namespace Com.AugustCellars.CoAP.Server
         {
 
             public RootResource(CoapServer server)
-                : base(String.Empty)
+                : base(string.Empty)
             {
             }
 
             protected override void DoGet(CoapExchange exchange)
             {
-
-                exchange.Respond("Ni Hao from CoAP.NET " + Spec.Name);
+                exchange.Respond("Ni Hao from Com.AugustCellars.CoAP " + Spec.Name);
             }
         }
     }

--- a/CoAP.Test/OSCOAP/Callbacks.cs
+++ b/CoAP.Test/OSCOAP/Callbacks.cs
@@ -1,0 +1,352 @@
+﻿using System;
+using System.Text;
+using System.Threading;
+using Com.AugustCellars.CoAP;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Com.AugustCellars.CoAP.Server;
+using Com.AugustCellars.CoAP.Net;
+using Com.AugustCellars.CoAP.Log;
+using Com.AugustCellars.CoAP.OSCOAP;
+using Com.AugustCellars.CoAP.Server.Resources;
+using Com.AugustCellars.COSE;
+
+namespace CoAP.Test.Std10.OSCOAP
+{
+    [TestClass]
+    public class Callbacks
+    {
+        private int _serverPort;
+        private CoapServer _server;
+        private OscoreEvent.EventCode _callbackCode;
+        private static readonly byte[] clientId = Encoding.UTF8.GetBytes("client");
+        private static readonly byte[] clientId2 = Encoding.UTF8.GetBytes("client2");
+        private static readonly byte[] serverId = Encoding.UTF8.GetBytes("server");
+        private static readonly byte[] serverId2 = Encoding.UTF8.GetBytes("server2");
+        private static readonly byte[] groupId1 = Encoding.UTF8.GetBytes("Group1");
+        private static readonly byte[] groupId2 = Encoding.UTF8.GetBytes("Group2");
+        private static readonly byte[] secret = new byte[] { 01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23 };
+        private static readonly byte[] secret2 = new byte[] { 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24 };
+
+        private static OneKey _clientSign1;
+        private static OneKey _clientSign2;
+        private static OneKey _serverSign1;
+
+        [ClassInitialize]
+        public static void ClassInit(TestContext e)
+        {
+            _clientSign1 = OneKey.GenerateKey(AlgorithmValues.EdDSA, GeneralValues.KeyType_OKP);
+            _clientSign2 = OneKey.GenerateKey(AlgorithmValues.EdDSA, GeneralValues.KeyType_OKP);
+            _serverSign1 = OneKey.GenerateKey(AlgorithmValues.EdDSA, GeneralValues.KeyType_OKP);
+        }
+
+        [TestInitialize]
+        public void SetupServer()
+        {
+            LogManager.Level = LogLevel.Fatal;
+            CreateServer();
+        }
+
+        [TestCleanup]
+        public void ShutdownServer()
+        {
+            _server.Stop();
+            _server.Dispose();
+        }
+
+        private int _clientEventChoice;
+        private OscoreEvent.EventCode _clientCallbackCode;
+        private void ClientEventHandler(object o, OscoreEvent e)
+        {
+            _clientCallbackCode = e.Code;
+            switch (_clientEventChoice) {
+            case 0:
+                _callbackCode = e.Code;
+                break;
+
+            case 1:
+                _callbackCode = e.Code;
+                e.SecurityContext = SecurityContext.DeriveGroupContext(secret2, groupId2, clientId, AlgorithmValues.EdDSA, _clientSign1, null, null);
+                break;
+
+            default:
+                Assert.Fail();
+                break;
+            }
+        }
+
+
+        [TestMethod]
+        public void PivExhaustion()
+        {
+            SecurityContext context = SecurityContext.DeriveGroupContext(secret, groupId1, clientId, AlgorithmValues.EdDSA, _clientSign1, null, null);
+            SecurityContext context2 = SecurityContext.DeriveGroupContext(secret2, groupId2, clientId, AlgorithmValues.EdDSA, _clientSign1, null, null);
+            for (int i = 0; i < 10; i++) {
+                context.Sender.IncrementSequenceNumber();
+            }
+
+            context.Sender.MaxSequenceNumber = 10;
+            context.OscoreEvents += ClientEventHandler;
+
+            CoapClient client = new CoapClient($"coap://localhost:{_serverPort}/abc") {
+                OscoreContext = context,
+                Timeout = 20
+            };
+
+            Response r = client.Get();
+
+            Assert.AreEqual(OscoreEvent.EventCode.PivExhaustion, _clientCallbackCode);
+
+            _clientEventChoice = 1;
+            client.Timeout = 1000 * 60;
+            r = client.Get();
+            Assert.AreEqual(OscoreEvent.EventCode.UnknownGroupIdentifier, _callbackCode);
+
+        }
+
+        [TestMethod]
+        public void NoGroupId()
+        {
+            SecurityContext context = SecurityContext.DeriveGroupContext(secret, groupId1, clientId, AlgorithmValues.EdDSA, _clientSign1, null, null);
+
+            CoapClient client = new CoapClient($"coap://localhost:{_serverPort}/abc") {
+                OscoreContext = context,
+//                Timeout = 60
+            };
+            Console.WriteLine($"--Server port = {_serverPort}");
+
+
+            Response r = client.Get();
+            Assert.AreEqual(OscoreEvent.EventCode.UnknownGroupIdentifier, _callbackCode);
+        }
+
+        [TestMethod]
+        public void SetGroupId()
+        {
+            SecurityContext context = SecurityContext.DeriveGroupContext(secret, groupId1, clientId, AlgorithmValues.EdDSA, _clientSign1,
+                new byte[][]{serverId},  new OneKey[]{_serverSign1});
+
+            CoapClient client = new CoapClient($"coap://localhost:{_serverPort}/abc") {
+                OscoreContext = context,
+                Timeout = 60*1000
+            };
+            Console.WriteLine($"--Server port = {_serverPort}");
+
+            _serverEventChoice = 1;
+            Response r = client.Get();
+            Assert.AreEqual("/abc", r.PayloadString);
+        }
+
+        [TestMethod]
+        public void MissingKeyId()
+        {
+            SecurityContext context = SecurityContext.DeriveGroupContext(secret, groupId1, clientId, AlgorithmValues.EdDSA, _clientSign1,
+                new byte[][] { serverId }, new OneKey[] { _serverSign1 });
+            SecurityContext serverContext = SecurityContext.DeriveGroupContext(secret, groupId1, serverId, AlgorithmValues.EdDSA, _serverSign1,
+                new byte[][]{clientId2}, new OneKey[]{_clientSign2});
+            _server.SecurityContexts.Add(serverContext);
+            serverContext.OscoreEvents += ServerEventHandler;
+
+            CoapClient client = new CoapClient($"coap://localhost:{_serverPort}/abc")
+            {
+                OscoreContext = context,
+                Timeout = 60 * 1000
+            };
+
+            _serverEventChoice = 0;
+            Response r = client.Get();
+            Assert.AreEqual(OscoreEvent.EventCode.UnknownKeyIdentifier, _callbackCode);
+        }
+
+        [TestMethod]
+        public void SupplyMissingKeyId()
+        {
+            SecurityContext context = SecurityContext.DeriveGroupContext(secret, groupId1, clientId, AlgorithmValues.EdDSA, _clientSign1,
+                new byte[][] { serverId }, new OneKey[] { _serverSign1 });
+            SecurityContext serverContext = SecurityContext.DeriveGroupContext(secret, groupId1, serverId, AlgorithmValues.EdDSA, _serverSign1,
+                new byte[][] { clientId2 }, new OneKey[] { _clientSign2 });
+            _server.SecurityContexts.Add(serverContext);
+            serverContext.OscoreEvents += ServerEventHandler;
+
+            CoapClient client = new CoapClient($"coap://localhost:{_serverPort}/abc")
+            {
+                OscoreContext = context,
+                Timeout = 60 * 1000
+            };
+
+            _serverEventChoice = 2;
+            Response r = client.Get();
+
+            Assert.AreEqual("/abc", r.PayloadString);
+
+        }
+
+        [TestMethod]
+        public void ServerIvExhaustion()
+        {
+            SecurityContext context = SecurityContext.DeriveGroupContext(secret, groupId1, clientId, AlgorithmValues.EdDSA, _clientSign1,
+                new byte[][] { serverId }, new OneKey[] { _serverSign1 });
+            SecurityContext serverContext = SecurityContext.DeriveGroupContext(secret, groupId1, serverId, AlgorithmValues.EdDSA, _serverSign1,
+                new byte[][] { clientId2, clientId }, new OneKey[] { _clientSign2, _clientSign1 });
+            _server.SecurityContexts.Add(serverContext);
+            serverContext.OscoreEvents += ServerEventHandler;
+
+            for (int i = 0; i < 10; i++) {
+                serverContext.Sender.IncrementSequenceNumber();
+            }
+
+            serverContext.Sender.MaxSequenceNumber = 10;
+
+            CoapClient client = new CoapClient($"coap://localhost:{_serverPort}/abc")
+            {
+                OscoreContext = context,
+                Timeout = 60 * 1000
+            };
+
+            _serverEventChoice = 0;
+            Response r = client.Get();
+            Assert.IsNotNull(r);
+            Assert.AreEqual("/abc", r.PayloadString);
+
+            client = new CoapClient($"coap://localhost:{_serverPort}/abc") {
+                OscoreContext = context,
+                Timeout = 30 * 1000,
+            };
+            client.Observe();
+
+            Assert.AreEqual(OscoreEvent.EventCode.PivExhaustion, _callbackCode);
+        }
+
+        [TestMethod]
+        public void ServerNewSender()
+        {
+            SecurityContext context = SecurityContext.DeriveGroupContext(secret, groupId1, clientId, AlgorithmValues.EdDSA, _clientSign1,
+                new byte[][] {serverId, serverId2}, new OneKey[] {_serverSign1, _serverSign1});
+            SecurityContext serverContext = SecurityContext.DeriveGroupContext(secret, groupId1, serverId, AlgorithmValues.EdDSA, _serverSign1,
+                new byte[][] {clientId2, clientId}, new OneKey[] {_clientSign2, _clientSign1});
+            _server.SecurityContexts.Add(serverContext);
+            serverContext.OscoreEvents += ServerEventHandler;
+
+            for (int i = 0; i < 10; i++) {
+                serverContext.Sender.IncrementSequenceNumber();
+            }
+
+            serverContext.Sender.MaxSequenceNumber = 10;
+
+            CoapClient client = new CoapClient($"coap://localhost:{_serverPort}/abc") {
+                OscoreContext = context,
+                Timeout = 60 * 1000
+            };
+
+            _serverEventChoice = 3;
+            client.Observe(o => { Assert.AreEqual("/abc", o.PayloadString); });
+
+            Assert.AreEqual(OscoreEvent.EventCode.PivExhaustion, _callbackCode);
+        }
+
+        [TestMethod]
+        public void ServerNewSenderGroup()
+        {
+            SecurityContext context = SecurityContext.DeriveGroupContext(secret, groupId1, clientId, AlgorithmValues.EdDSA, _clientSign1,
+                new byte[][] { serverId, serverId2 }, new OneKey[] { _serverSign1, _serverSign1 });
+            SecurityContext serverContext = SecurityContext.DeriveGroupContext(secret, groupId1, serverId, AlgorithmValues.EdDSA, _serverSign1,
+                new byte[][] { clientId2, clientId }, new OneKey[] { _clientSign2, _clientSign1 });
+            _server.SecurityContexts.Add(serverContext);
+            serverContext.OscoreEvents += ServerEventHandler;
+
+            serverContext.Sender.SequenceNumber = 10;
+
+            serverContext.Sender.MaxSequenceNumber = 10;
+
+            CoapClient client = new CoapClient($"coap://localhost:{_serverPort}/abc")
+            {
+                OscoreContext = context,
+                Timeout = 60 * 1000
+            };
+
+            _serverEventChoice = 4;
+            client.Observe(o => { Assert.AreEqual("/abc", o.PayloadString); });
+
+            Assert.AreEqual(OscoreEvent.EventCode.PivExhaustion, _callbackCode);
+        }
+
+        private void CreateServer()
+        {
+            CoAPEndPoint endpoint = new CoAPEndPoint(0);
+            _server = new CoapServer();
+
+            //            _resource = new StorageResource(TARGET, CONTENT_1);
+            //           _server.Add(_resource);
+
+            Resource r2 = new EchoLocation("abc");
+            _server.Add(r2);
+
+            r2.Add(new EchoLocation("def"));
+
+            _server.AddEndPoint(endpoint);
+            _server.Start();
+            _serverPort = ((System.Net.IPEndPoint)endpoint.LocalEndPoint).Port;
+            Console.WriteLine($"Server port = {_serverPort}");
+
+            SecurityContextSet oscoapContexts = new SecurityContextSet();
+            _server.SecurityContexts.Add(SecurityContext.DeriveContext(secret, null, serverId, clientId));
+            _server.SecurityContexts.OscoreEvents += ServerEventHandler;
+        }
+
+        private int _serverEventChoice;
+
+        private void ServerEventHandler(object o, OscoreEvent e)
+        {
+            _callbackCode = e.Code;
+            switch (_serverEventChoice) {
+            case 0:
+                break;
+
+            case 1:
+                e.SecurityContext = SecurityContext.DeriveGroupContext(secret, groupId1, serverId, AlgorithmValues.EdDSA, _serverSign1,
+                    new byte[][]{clientId}, new OneKey[]{_clientSign1});
+                break;
+
+                case 2:
+                    e.SecurityContext.AddRecipient(clientId, _clientSign1);
+                    e.RecipientContext = e.SecurityContext.Recipients[clientId];
+                    break;
+
+                case 3:
+                    e.SecurityContext.ReplaceSender(serverId2, _serverSign1);
+                    break;
+
+                case 4:
+                    e.SecurityContext = SecurityContext.DeriveGroupContext(secret2, groupId2, serverId, AlgorithmValues.EdDSA, _serverSign1,
+                        new byte[][]{clientId}, new OneKey[]{_clientSign1} );
+                    break;
+
+            default:
+                Assert.Fail();
+                break;
+            }
+        }
+
+        class EchoLocation : Resource
+        {
+
+            public EchoLocation(String name)
+                : base(name)
+            {
+                Observable = true;
+                RequireSecurity = true;
+            }
+
+            protected override void DoGet(CoapExchange exchange)
+            {
+                String c = this.Uri;
+                String querys = exchange.Request.UriQuery;
+                if (querys != "")
+                {
+                    c += "?" + querys;
+                }
+
+                exchange.Respond(c);
+            }
+        }
+    }
+}

--- a/CoAP.Test/OSCOAP/Oscoap.cs
+++ b/CoAP.Test/OSCOAP/Oscoap.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Com.AugustCellars.CoAP.Net;
-using Com.AugustCellars.CoAP.OSCOAP;
 using Com.AugustCellars.CoAP.Server;
 using Com.AugustCellars.CoAP.Server.Resources;
 
@@ -15,15 +11,11 @@ namespace Com.AugustCellars.CoAP.OSCOAP
     [TestClass]
     public class Oscoap
     {
-        Int32 _serverPort;
+        int _serverPort;
         CoapServer _server;
-        Resource _resource;
-        String _expected;
-        Int32 _notifications;
-        Boolean _failed;
-        private static readonly byte[] _ClientId = Encoding.UTF8.GetBytes("client");
-        private static readonly byte[] _ServerId = Encoding.UTF8.GetBytes("server");
-        private static readonly byte[] _Secret = new byte[] { 01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23 };
+        private static readonly byte[] clientId = Encoding.UTF8.GetBytes("client");
+        private static readonly byte[] serverId = Encoding.UTF8.GetBytes("server");
+        private static readonly byte[] secret = new byte[] { 01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23 };
 
 
         [TestInitialize]
@@ -43,11 +35,10 @@ namespace Com.AugustCellars.CoAP.OSCOAP
         public void Ocoap_Get()
         {
             CoapClient client = new CoapClient($"coap://localhost:{_serverPort}/abc") {
-                OscoreContext = SecurityContext.DeriveContext(_Secret, null, _ClientId, _ServerId)
+                OscoreContext = SecurityContext.DeriveContext(secret, null, clientId, serverId)
             };
             Response r = client.Get();
             Assert.AreEqual("/abc", r.PayloadString);
-
         }
 
         private void CreateServer()
@@ -68,7 +59,7 @@ namespace Com.AugustCellars.CoAP.OSCOAP
             _serverPort = ((System.Net.IPEndPoint) endpoint.LocalEndPoint).Port;
 
             SecurityContextSet oscoapContexts = new SecurityContextSet();
-            SecurityContextSet.AllContexts.Add(SecurityContext.DeriveContext(_Secret, null, _ServerId, _ClientId));
+            _server.SecurityContexts.Add(SecurityContext.DeriveContext(secret, null, serverId, clientId));
         }
 
         class EchoLocation : Resource


### PR DESCRIPTION
Put the functionality in place for doing group rollover of groups.

* Define a new class for OSCORE events
* Put the event notification points for those events
* Make the server security context set be set on the server and no longer global
* Add functions to the SecurityContext for setting up group roll overs.