### PR TITLE
Fix finding resource from path

### DIFF
--- a/CoAP.NET/Server/CoapServer.cs
+++ b/CoAP.NET/Server/CoapServer.cs
@@ -258,7 +258,7 @@ namespace Com.AugustCellars.CoAP.Server
 
             foreach (string path in pathStrings) {
                 if (string.IsNullOrEmpty(path)) continue;
-                resource = _root.GetChild(path);
+                resource = resource.GetChild(path);
                 if (resource == null) return null;
             }
 


### PR DESCRIPTION
Method for finding a resource from path was searching only in root resource.
It it supposed to iteratively go through the resource tree according to the path.