### PR TITLE
Add ability remove Options in CoapClient

### DIFF
--- a/CoAP.NET/CoAP.Std10.csproj
+++ b/CoAP.NET/CoAP.Std10.csproj
@@ -28,6 +28,7 @@ It is intented primarily for research and verification work.
   - Rename OSCOAP option to OSCORE - this should not affect anybody as it should only be used internally
   - Correct secure blockwise code to have the original request options as part of the key and the next block message
   - Add testing and do some correction to the multicast code
+  - Add ability remove Options in CoapClient
 1.8
   - Internal cleanup work.
   - Add congestion control for observe notifications

--- a/CoAP.NET/CoapClient.cs
+++ b/CoAP.NET/CoapClient.cs
@@ -25,6 +25,7 @@ namespace Com.AugustCellars.CoAP
         private static readonly IEnumerable<WebLink> _EmptyLinks = new WebLink[0];
         private readonly ICoapConfig _config;
         private MessageType _type = MessageType.CON;
+        private readonly List<OptionType> _removedOptions = new List<OptionType>();
 
         /// <summary>
         /// Occurs when a response has arrived.
@@ -639,6 +640,15 @@ namespace Com.AugustCellars.CoAP
             Prepare(request).Send();
         }
 
+        public void RemoveOptions(OptionType optionType)
+        {
+            if(_removedOptions.Contains(optionType))
+            {
+                return;
+            }
+            _removedOptions.Add(optionType);
+        }
+
         /// <summary>
         /// Set properties on the request that are based on properties on this object
         /// </summary>
@@ -675,6 +685,10 @@ namespace Com.AugustCellars.CoAP
 
             if (endpoint != null) {
                 request.EndPoint = endpoint;
+            }
+
+            foreach(var option in _removedOptions) {
+                request.RemoveOptions(option);
             }
 
             return request;


### PR DESCRIPTION
Adds the ability to remove Options in CoapClient, similar to how you can for a Request.

This was required in my case to remove UriPort which was not supported by a CoAP server I am connecting to.

See #78 