### PR TITLE
Use the old API if the new one is not supported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ lib
 .svn
 Apps
 cov-int
+_ReSharper.Caches
 
 # DNX project file with a complete list of resolved dependencies
 project.lock.json

--- a/CoAP.NET/Channel/UDPChannel.NET40.cs
+++ b/CoAP.NET/Channel/UDPChannel.NET40.cs
@@ -20,6 +20,8 @@ namespace Com.AugustCellars.CoAP.Channel
 {
     public partial class UDPChannel
     {
+        private bool UseReceiveMessageFrom = true;
+
         private UDPSocket NewUDPSocket(AddressFamily addressFamily, int bufferSize)
         {
             return new UDPSocket(addressFamily, bufferSize, SocketAsyncEventArgs_Completed);
@@ -49,7 +51,16 @@ namespace Com.AugustCellars.CoAP.Channel
 #if LOG_UDP_CHANNEL
                 _Log.Debug("BeginReceive:  Start async read");
 #endif
-                willRaiseEvent = socket.Socket.ReceiveMessageFromAsync(socket.ReadBuffer);
+                if (UseReceiveMessageFrom) {
+                    willRaiseEvent = socket.Socket.ReceiveMessageFromAsync(socket.ReadBuffer);
+                }
+                else {
+                    willRaiseEvent = socket.Socket.ReceiveFromAsync(socket.ReadBuffer);
+                }
+            }
+            catch (NotImplementedException) {
+                UseReceiveMessageFrom = false;
+                willRaiseEvent = socket.Socket.ReceiveFromAsync(socket.ReadBuffer);
             }
             catch (ObjectDisposedException) {
 #if LOG_UDP_CHANNEL

--- a/CoAP.NET/CoAP.Std10.csproj
+++ b/CoAP.NET/CoAP.Std10.csproj
@@ -23,6 +23,8 @@
 This project is built on the CoAP.NET project of smeshlink which in turn is based on Californium.  As this project did not seem to be maintained any more and I wanted a version in order to test the newer items that are coming out of the IETF CORE working group, I have captured it and started exanding it.
 It is intented primarily for research and verification work.
 
+1.10
+  - Add fallback code if UDP read function is not supported.  These platforms will no longer have full multicast support.
 1.9
   - Fix some errors in OSCORE processing with a large number of messages
   - Rename OSCOAP option to OSCORE - this should not affect anybody as it should only be used internally


### PR DESCRIPTION
If ReceiveMessageFromAsync is not supported, then fall back to the old function call.  This should address #81 