### PR TITLE
Fix a problem with order of notifications and proactive canceling

### DIFF
--- a/CoAP.NET/CoAP.Std10.csproj
+++ b/CoAP.NET/CoAP.Std10.csproj
@@ -25,6 +25,8 @@ It is intented primarily for research and verification work.
 
 1.10
   - Add fallback code if UDP read function is not supported.  These platforms will no longer have full multicast support.
+  - Enable the ability to change ETags on an observe relation
+  - Fix error where an observe would attempt to re-connect after active cancel
 1.9
   - Fix some errors in OSCORE processing with a large number of messages
   - Rename OSCOAP option to OSCORE - this should not affect anybody as it should only be used internally

--- a/CoAP.NET/Net/Matcher.cs
+++ b/CoAP.NET/Net/Matcher.cs
@@ -78,16 +78,20 @@ namespace Com.AugustCellars.CoAP.Net
         /// <inheritdoc/>
         public void Start()
         {
-            if (System.Threading.Interlocked.CompareExchange(ref _running, 1, 0) > 0)
+            if (System.Threading.Interlocked.CompareExchange(ref _running, 1, 0) > 0) {
                 return;
+            }
+
             _deduplicator.Start();
         }
 
         /// <inheritdoc/>
         public void Stop()
         {
-            if (System.Threading.Interlocked.Exchange(ref _running, 0) == 0)
+            if (System.Threading.Interlocked.Exchange(ref _running, 0) == 0) {
                 return;
+            }
+
             _deduplicator.Stop();
             Clear();
         }
@@ -147,7 +151,6 @@ namespace Com.AugustCellars.CoAP.Net
             }
 
             exchange.Completed += OnExchangeCompleted;
-
 
             _Log.Debug(m => m("Stored open request by {0}, {1}", keyID, keyToken));
 
@@ -447,6 +450,9 @@ namespace Com.AugustCellars.CoAP.Net
                 // this endpoint created the Exchange to respond a request
 
                 Response response = exchange.CurrentResponse;
+                if (response == null) {
+                    response = exchange.Response;
+                }
                 if (response != null && response.Type != MessageType.ACK) {
                     // only response MIDs are stored for ACK and RST, no reponse Tokens
                     Exchange.KeyID midKey = new Exchange.KeyID(response.ID, null, response.Session);

--- a/CoAP.NET/Request.cs
+++ b/CoAP.NET/Request.cs
@@ -173,6 +173,11 @@ namespace Com.AugustCellars.CoAP
         }
 
         /// <summary>
+        /// The observe relationship if one exists.
+        /// </summary>
+        public CoapObserveRelation ObserveRelation { get; set; }
+
+        /// <summary>
         /// Gets or sets the response to this request.
         /// </summary>
         public Response Response
@@ -204,7 +209,12 @@ namespace Com.AugustCellars.CoAP
         /// Should we attempt to reconnect to keep an observe relationship fresh
         /// in the event the MAX-AGE expires on the current value?
         /// </summary>
-        public bool ObserveReconnect { get; set; } = true;
+        [Obsolete("Use ObserveRelation.Reconnect instead")]
+        public bool ObserveReconnect
+        {
+            get => ObserveRelation.Reconnect;
+            set => ObserveRelation.Reconnect = value;
+        }
 
         /// <summary>
         /// Sets CoAP's observe option. If the target resource of this request

--- a/CoAP.NET/Stack/ReliabilityLayer.cs
+++ b/CoAP.NET/Stack/ReliabilityLayer.cs
@@ -237,7 +237,7 @@ namespace Com.AugustCellars.CoAP.Stack
                         exchange.CurrentRequest.IsRejected = true;
                     }
                     else {
-                        exchange.CurrentResponse.IsRejected = true;
+                        exchange.Response.IsRejected = true;
                     }
 
                     break;

--- a/CoAP.NET/Stack/ReliabilityLayer.cs
+++ b/CoAP.NET/Stack/ReliabilityLayer.cs
@@ -256,6 +256,9 @@ namespace Com.AugustCellars.CoAP.Stack
 
         private void PrepareRetransmission(Exchange exchange, Message msg, Action<TransmissionContext> retransmit)
         {
+            if (_maxRetransmitCount == 0) {
+                return;
+            }
             TransmissionContext ctx = exchange.GetOrAdd<TransmissionContext>(
                 _TransmissionContextKey, _ => new TransmissionContext(_config, exchange, msg, retransmit, _maxRetransmitCount));
 

--- a/CoAP.NET/Stack/TokenLayer.cs
+++ b/CoAP.NET/Stack/TokenLayer.cs
@@ -21,9 +21,6 @@ namespace Com.AugustCellars.CoAP.Stack
     /// </summary>
     public class TokenLayer : AbstractLayer
     {
-#if false
-        private Int32 _counter;
-#endif
         private static ILogger _Log = LogManager.GetLogger("TokenLayer");
 
         /// <summary>
@@ -31,13 +28,9 @@ namespace Com.AugustCellars.CoAP.Stack
         /// </summary>
         public TokenLayer(ICoapConfig config)
         {
-#if false
-            if (config.UseRandomTokenStart) {
-                _counter = new Random().Next();
-            }
-#endif
         }
 
+#if false
         /// <inheritdoc/>
         public override void SendRequest(INextLayer nextLayer, Exchange exchange, Request request)
         {
@@ -49,6 +42,7 @@ namespace Com.AugustCellars.CoAP.Stack
 #endif
             base.SendRequest(nextLayer, exchange, request);
         }
+#endif
 
         /// <inheritdoc/>
         public override void SendResponse(INextLayer nextLayer, Exchange exchange, Response response)
@@ -80,17 +74,5 @@ namespace Com.AugustCellars.CoAP.Stack
             }
             base.ReceiveResponse(nextLayer, exchange, response);
         }
-
-#if false
-        private Byte[] NewToken()
-        {
-            UInt32 token = (UInt32)System.Threading.Interlocked.Increment(ref _counter);
-            return new Byte[]
-            { 
-                (Byte)(token >> 24), (Byte)(token >> 16),
-                (Byte)(token >> 8), (Byte)token
-            };
-        }
-#endif
     }
 }

--- a/CoAP.Test/MockDriver/MockChannel.cs
+++ b/CoAP.Test/MockDriver/MockChannel.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using CoAP.Test.Std10.MockItems;
+using Com.AugustCellars.CoAP;
+using Com.AugustCellars.CoAP.Channel;
+using Com.AugustCellars.CoAP.Codec;
+
+namespace CoAP.Test.Std10.MockDriver
+{
+    public enum DeliveryInstrutions
+    {
+        Deliver = 0,
+        Omit = 1,
+        DeferBy1 = 9,
+        DeferBy2 = 10,
+        DeferBy3 = 11,
+        DeferBy4 = 12,
+        DeferBy5 = 13,
+        DupAndDeferBy0 = 16,
+        DupAndDeferBy1 = 17,
+        DupAndDeferBy2 = 18,
+        DupAndDeferBy3 = 19,
+        DupAndDeferBy4 = 20,
+        DupAndDeferBy5 = 21,
+        DupAndDeferBy6 = 22
+    }
+
+
+
+    public class MockChannel : IChannel
+    {
+        public class TransportItem
+        {
+            public MockQueueItem Item { get; }
+            public int DelayCount { get; set; }
+
+            public TransportItem(MockQueueItem item, int delay)
+            {
+                Item = item;
+                DelayCount = delay;
+            }
+        };
+
+        private List<TransportItem> DelayList = new List<TransportItem>();
+        public DeliveryInstrutions[] DeliveryRules { get; set; }
+        private int deliveryPoint = 0;
+
+        private MockMessagePump Pump { get; }
+        private MockSession Session { get; } = new MockSession();
+
+        public MockChannel(EndPoint localEndpoint, MockMessagePump pump)
+        {
+            LocalEndPoint = localEndpoint;
+            Pump = pump;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public EndPoint LocalEndPoint { get; }
+
+        /// <inheritdoc />
+        public event EventHandler<DataReceivedEventArgs> DataReceived;
+
+        /// <inheritdoc />
+        public bool AddMulticastAddress(IPEndPoint ep)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void Start()
+        {
+            //  Nothing to do
+            return;
+        }
+
+        /// <inheritdoc />
+        public void Stop()
+        {
+            //  Nothing to do
+            return;
+        }
+
+        /// <inheritdoc />
+        public void Abort(ISession session)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void Release(ISession session)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void Send(byte[] data, ISession session, EndPoint ep)
+        {
+            MockQueueItem item = new MockQueueItem(MockQueueItem.QueueType.NetworkSend, data);
+            item.Destination = ep;
+            item.Source = LocalEndPoint;
+            
+            MessageDecoder decoder = new Spec.MessageDecoder18(data);
+            if (decoder.IsRequest) {
+                item.Request = decoder.DecodeRequest();
+            }
+            else if (decoder.IsResponse) {
+                item.Response = decoder.DecodeResponse();
+            }
+            else if (decoder.IsEmpty) {
+                item.EmptyMessage = decoder.DecodeEmptyMessage();
+            }
+            else {
+                throw new Exception("UNKNOWN MESSAGE TYPE");
+            }
+
+            DeliveryInstrutions rule = DeliveryInstrutions.Deliver;
+
+            if (DeliveryRules != null && deliveryPoint < DeliveryRules.Length) {
+                int defer = -1;
+                switch (DeliveryRules[deliveryPoint]) {
+                    case DeliveryInstrutions.Deliver:
+                        break;
+
+                    case DeliveryInstrutions.DeferBy1:
+                    case DeliveryInstrutions.DeferBy2:
+                    case DeliveryInstrutions.DeferBy3:
+                    case DeliveryInstrutions.DeferBy4:
+                    case DeliveryInstrutions.DeferBy5:
+                        defer = DeliveryRules[deliveryPoint] - DeliveryInstrutions.DeferBy1 + 1;
+                        rule = DeliveryInstrutions.Omit;
+                        break;
+
+                    case DeliveryInstrutions.DupAndDeferBy0:
+                    case DeliveryInstrutions.DupAndDeferBy1:
+                    case DeliveryInstrutions.DupAndDeferBy2:
+                    case DeliveryInstrutions.DupAndDeferBy3:
+                    case DeliveryInstrutions.DupAndDeferBy4:
+                        defer = DeliveryRules[deliveryPoint] - DeliveryInstrutions.DupAndDeferBy0;
+                        break;
+                }
+
+                if (defer >= 0) {
+                    int insertAt = 0;
+                    foreach (TransportItem t in DelayList) {
+                        if (t.DelayCount > defer) {
+                            break;
+                        }
+
+                        insertAt += 1;
+                    }
+
+                    DelayList.Insert(insertAt, new TransportItem(item, defer));
+                }
+            }
+
+            if (rule == DeliveryInstrutions.Deliver) {
+                Pump.Queue.Enqueue(item);
+            }
+
+            if (DelayList.Count > 0) {
+                int removeCount = 0;
+                foreach (TransportItem t in DelayList) {
+                    t.DelayCount -= 1;
+                    if (t.DelayCount == 0) {
+                        Pump.Queue.Enqueue(t.Item);
+                        removeCount += 1;
+                    }
+                }
+
+                if (removeCount > 0) {
+                    DelayList.RemoveRange(0, removeCount);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public ISession GetSession(EndPoint ep)
+        {
+            return Session;
+        }
+
+        public void ReceiveData(MockQueueItem item)
+        {
+            DataReceivedEventArgs args = new DataReceivedEventArgs(item.ItemData, item.Source, item.Destination, Session);
+            DataReceived?.Invoke(this, args);
+        }
+    }
+}

--- a/CoAP.Test/MockDriver/MockDeliverer.cs
+++ b/CoAP.Test/MockDriver/MockDeliverer.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using CoAP.Test.Std10.MockItems;
 using Com.AugustCellars.CoAP;
 using Com.AugustCellars.CoAP.Net;
 
-namespace CoAP.Test.Std10.MockItems
+namespace CoAP.Test.Std10.MockDriver
 {
     public class MockDeliverer : IMessageDeliverer
     {

--- a/CoAP.Test/MockDriver/MockMessagePump.cs
+++ b/CoAP.Test/MockDriver/MockMessagePump.cs
@@ -243,9 +243,10 @@ namespace CoAP.Test.Std10.MockDriver
                     s.MyEndPoint.ReceiveData(item);
                 }
 
-                //                    ClientEndpoint.ReceiveData(item);
-
                 break;
+
+                case MockQueueItem.QueueType.ClientSendResponse:
+                    break;
 
             // state #8 - client application to process response
             case MockQueueItem.QueueType.ClientSendEmptyMessageNetwork:

--- a/CoAP.Test/MockDriver/MockMessagePump.cs
+++ b/CoAP.Test/MockDriver/MockMessagePump.cs
@@ -1,32 +1,55 @@
-﻿using System;
+﻿/*
+ * Copyright (c) 2020, Jim Schaad <ietf@augustcellars.com>
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY.
+ * 
+ * This file is part of the CoAP.NET, a CoAP framework in C#.
+ * Please see README for more information.
+ */
+
+using System;
 using System.Collections.Generic;
-using System.Dynamic;
+using System.Linq;
 using System.Net;
-using System.Text;
-using CoAP.Test.Std10.OSCOAP;
+using CoAP.Test.Std10.MockItems;
 using Com.AugustCellars.CoAP;
+using Com.AugustCellars.CoAP.Channel;
 using Com.AugustCellars.CoAP.Codec;
 using Com.AugustCellars.CoAP.Net;
+using Com.AugustCellars.CoAP.Server;
+using Com.AugustCellars.CoAP.Server.Resources;
 using Com.AugustCellars.CoAP.Stack;
+using Com.AugustCellars.CoAP.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace CoAP.Test.Std10.MockItems
+namespace CoAP.Test.Std10.MockDriver
 {
     public class MockMessagePump
     {
+        /// <summary>
+        /// Queue of network events that are still to be processed.
+        /// If the mock deliverer is used, then the delivery events will also be on the queue.
+        /// </summary>
+        public Queue<MockQueueItem> Queue { get; } = new Queue<MockQueueItem>();
 
-        public Queue<MockQueueItem> Queue = new Queue<MockQueueItem>();
+
         public MockStack ClientStack { get; set; }
 
-        public static EndPoint ClientAddress { get;  } = new IPEndPoint(0x010044c0, 5683);
+        public static EndPoint ClientAddress { get; } = new IPEndPoint(0x010044c0, 5683);
         public static EndPoint ServerAddress { get; } = new IPEndPoint(0xF00044c0, 5683);
-        public static EndPoint ServerAddress2 { get;  } = new IPEndPoint(0xF10044c0, 5683);
+        public static EndPoint ServerAddress2 { get; } = new IPEndPoint(0xF10044c0, 5683);
         public static EndPoint MulticastAddress { get; } = new IPEndPoint(IPAddress.Parse("224.0.0.9"), 5683);
 
         public Dictionary<EndPoint, List<MockStack>> ServerStacks { get; } = new Dictionary<EndPoint, List<MockStack>>();
+        public Dictionary<EndPoint, List<MockChannel>> ChannelsByEndpoint { get;  } = new Dictionary<EndPoint, List<MockChannel>>();
 
         private MockEndpoint ClientEndpoint { get; }
-        private IMessageDeliverer ClientDeliverer { get; }
+
+        public MockMessagePump()
+        {
+
+        }
 
         public MockMessagePump(Type[] layers, ICoapConfig configClient = null, ICoapConfig configServer = null)
         {
@@ -38,57 +61,95 @@ namespace CoAP.Test.Std10.MockItems
                 configServer = CoapConfig.Default;
             }
 
-            ClientStack = new MockStack(layers, configClient) {
-                StackName = "Client"
-            };
+            ClientEndpoint = AddClientEndpoint("Client", (IPEndPoint) ClientAddress, configClient, layers, true);
+            ClientStack = ServerStacks[ClientAddress].First();
 
-            MockStack stack = new MockStack(layers, configServer) {
-                StackName = "Server #1"
-            };
-            ServerStacks.Add(ServerAddress, new List<MockStack>(){stack});
-            stack.MyEndPoint = new MockEndpoint(this, stack, ServerAddress);
-            ServerStacks.Add(MulticastAddress, new List<MockStack>(){stack});
-            MockDeliverer serverDeliverer = new MockDeliverer()
-            {
-                IsServer = true,
-                Pump = this
-            };
-            stack.MyEndPoint.MessageDeliverer = serverDeliverer;
+            AddServerEndpoint("Server #1", (IPEndPoint) ServerAddress, configServer, layers, true);
+            MockStack x = ServerStacks[ServerAddress].First();
+            AddEndpointToAddress((IPEndPoint) MulticastAddress, x);
 
-
-            stack = new MockStack(layers, configServer) {
-                StackName = "Server #2"
-            };
-            ServerStacks.Add(ServerAddress2, new List<MockStack>(){stack});
-            stack.MyEndPoint = new MockEndpoint(this, stack, ServerAddress2);
-            ServerStacks[MulticastAddress].Add(stack);
-            serverDeliverer = new MockDeliverer()
-            {
-                IsServer = true,
-                Pump = this
-            };
-            stack.MyEndPoint.MessageDeliverer = serverDeliverer;
-
-            ClientEndpoint = new MockEndpoint(this, ClientStack, ClientAddress);
-            ClientDeliverer = new MockDeliverer() {
-                IsServer = false,
-                Pump = this
-            };
-            ClientEndpoint.MessageDeliverer = ClientDeliverer;
+            AddServerEndpoint("Server #2", (IPEndPoint) ServerAddress2, configServer, layers, true);
+            x = ServerStacks[ServerAddress2].First();
+            AddEndpointToAddress((IPEndPoint) MulticastAddress, x);
         }
 
-        private Exchange lastExchange;
-        public void RegisterExchange(Request request, Exchange exchange)
+        public MockEndpoint AddClientEndpoint(string endpointName, IPEndPoint endPoint, ICoapConfig config, Type[] layers, bool useMockDelivery = false)
         {
-            if (lastExchange != null) {
-                throw new Exception("Registration of exchanges is messed up.");
+            return AddEndPoint(endpointName, endPoint, config, layers, false, useMockDelivery);
+        }
+
+        public MockEndpoint AddServerEndpoint(string endpointName, IPEndPoint endPoint, ICoapConfig config, Type[] layers, bool useMockDelivery = false, IResource root = null)
+        {
+            return AddEndPoint(endpointName, endPoint, config, layers, true, useMockDelivery, root);
+        }
+
+        public MockEndpoint AddEndPoint(string endpointName, IPEndPoint endPoint, ICoapConfig config, Type[] layers, bool isServer, bool useMockDelivery = false, IResource root = null)
+        {
+            MockStack stack = new MockStack(layers, config) {
+                StackName = endpointName
+            };
+
+            MockEndpoint ep = new MockEndpoint(this, stack, endPoint);
+            stack.MyEndPoint = ep;
+
+            if (useMockDelivery) {
+                ep.MessageDeliverer = new MockDeliverer() {
+                    IsServer = isServer,
+                    Pump = this
+                };
             }
-            lastExchange = exchange;
+            else {
+                ep.MessageDeliverer = isServer ? new ServerMessageDeliverer(config, root) : (IMessageDeliverer) new ClientMessageDeliverer();
+            }
+
+            ServerStacks.Add(endPoint, new List<MockStack>() {stack});
+
+            return ep;
+        }
+
+
+
+        public IEndPoint AddEndPoint(string endpointName, EndPoint address, ICoapConfig config, Type[] layers)
+        {
+            MockChannel channel = new MockChannel(address, this);
+            CoAPEndPoint endpoint = new CoAPEndPoint(channel, config);
+
+            if (layers != null) {
+                CoapStack stack = endpoint.Stack;
+
+                foreach (IEntry<ILayer, INextLayer> e in stack.GetAll().ToArray()) {
+                    if (e.Name == "head" || e.Name == "tail") {
+                        continue;
+                    }
+                    if (!layers.Contains(e.Filter.GetType())) {
+                        stack.Remove(e.Filter);
+                    }
+                }
+
+            }
+
+            ChannelsByEndpoint.Add(address, new List<MockChannel>(){channel});
+
+            return endpoint;
+        }
+
+
+
+        public void AddEndpointToAddress(IPEndPoint ipAddress, MockStack endPoint)
+        {
+            List<MockStack> stacks;
+
+            if (!ServerStacks.TryGetValue(ipAddress, out stacks)) {
+                stacks = new List<MockStack>();
+                ServerStacks.Add(ipAddress, stacks);
+            }
+
+            stacks.Add(endPoint);
         }
 
         public void SendRequest(Request request)
         {
-                request.EndPoint = ClientEndpoint;
+            request.EndPoint = ClientEndpoint;
             MockQueueItem item = new MockQueueItem(MockQueueItem.QueueType.ClientSendRequest, request);
             Queue.Enqueue(item);
         }
@@ -117,6 +178,7 @@ namespace CoAP.Test.Std10.MockItems
                 if (item.Request.Destination == null) {
                     item.Request.Destination = ServerAddress;
                 }
+
                 ClientStack.SendRequest(item.Request);
                 break;
 
@@ -131,7 +193,7 @@ namespace CoAP.Test.Std10.MockItems
                 item.Source = ClientAddress;
                 item.Destination = destination;
                 Queue.Enqueue(item);
-                    break;
+                break;
 
             //  state #3 - server receives network send
             case MockQueueItem.QueueType.ServerSendRequestNetwork:
@@ -148,39 +210,78 @@ namespace CoAP.Test.Std10.MockItems
                 break;
 
 
-                // state #5 - server sends an response
-                case MockQueueItem.QueueType.ServerSendResponse:
+            // state #5 - server sends an response
+            case MockQueueItem.QueueType.ServerSendResponse:
+                Queue.Dequeue();
+                serverStacks = ServerStacks[item.Source];
+                Assert.AreEqual(1, serverStacks.Count);
+                foreach (MockStack s in serverStacks) {
+                    s.SendResponse(item.Exchange, item.Response);
+                }
+
+                break;
+
+            // state #6 - server ready to send over network
+            case MockQueueItem.QueueType.ServerSendResponseNetwork:
+                Queue.Dequeue();
+                encoder = new Spec.MessageEncoder18();
+                byte[] encodedResponse = encoder.Encode(item.Response);
+
+                MockQueueItem item2 = new MockQueueItem(MockQueueItem.QueueType.ClientSendResponseNetwork, encodedResponse);
+                item2.Source = item.Response.Source;
+                item2.Destination = item.Response.Destination;
+                Queue.Enqueue(item2);
+                break;
+
+            // state #7 - client receives response over network
+            case MockQueueItem.QueueType.ClientSendResponseNetwork:
+                Queue.Dequeue();
+
+                serverStacks = ServerStacks[item.Destination];
+                Assert.AreEqual(1, serverStacks.Count);
+                foreach (MockStack s in serverStacks) {
+                    s.MyEndPoint.ReceiveData(item);
+                }
+
+                //                    ClientEndpoint.ReceiveData(item);
+
+                break;
+
+            // state #8 - client application to process response
+            case MockQueueItem.QueueType.ClientSendEmptyMessageNetwork:
+                Queue.Dequeue();
+                encoder = new Spec.MessageEncoder18();
+                encodedRequest = encoder.Encode(item.EmptyMessage);
+
+                item2 = new MockQueueItem(MockQueueItem.QueueType.ServerSendEmptyMessageNetwork, encodedRequest);
+                item2.Source = item.Source;
+                item2.Destination = item.EmptyMessage.Destination;
+                Queue.Enqueue(item2);
+                break;
+
+            //  state #3 - server receives network send
+            case MockQueueItem.QueueType.ServerSendEmptyMessageNetwork:
+                Queue.Dequeue();
+                serverStacks = ServerStacks[item.Destination];
+                foreach (MockStack s in serverStacks) {
+                    s.MyEndPoint.ReceiveData(item);
+                }
+                break;
+
+                case MockQueueItem.QueueType.NetworkSend:
                     Queue.Dequeue();
-                    serverStacks = ServerStacks[item.Source];
-                    Assert.AreEqual(1, serverStacks.Count);
-                    foreach (MockStack s in serverStacks) {
-                        s.SendResponse(item.Exchange, item.Response);
+                    List<MockChannel> channels = ChannelsByEndpoint[item.Destination];
+
+                    foreach (MockChannel c in channels) {
+                        c.ReceiveData(item);
                     }
-                    break;
-
-                // state #6 - server ready to send over network
-                case MockQueueItem.QueueType.ServerSendResponseNetwork:
-                    Queue.Dequeue();
-                    encoder = new Spec.MessageEncoder18();
-                    byte[] encodedResponse = encoder.Encode(item.Response);
-
-                    MockQueueItem item2 = new MockQueueItem(MockQueueItem.QueueType.ClientSendResponseNetwork, encodedResponse);
-                    item2.Source = item.Response.Source;
-                    item2.Destination = item.Destination;
-                    Queue.Enqueue(item2);
-                    break;
-
-                // state #7 - client receives response over network
-                case MockQueueItem.QueueType.ClientSendResponseNetwork:
-                    Queue.Dequeue();
-
-                    ClientEndpoint.ReceiveData(item);
 
                     break;
 
-                // state #8 - client application to process response
-                case MockQueueItem.QueueType.ClientSendResponse:
-                    break;
+
+            default:
+                Assert.Fail("Unknown item in the pump");
+                break;
             }
 
             return Queue.Count > 0;

--- a/CoAP.Test/MockDriver/MockQueueItem.cs
+++ b/CoAP.Test/MockDriver/MockQueueItem.cs
@@ -1,8 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
+﻿/*
+ * Copyright (c) 2020, Jim Schaad <ietf@augustcellars.com>
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY.
+ * 
+ * This file is part of the CoAP.NET, a CoAP framework in C#.
+ * Please see README for more information.
+ */
+
 using System.Net;
-using System.Security.Cryptography;
-using System.Text;
 using Com.AugustCellars.CoAP;
 using Com.AugustCellars.CoAP.Net;
 
@@ -20,13 +26,21 @@ namespace CoAP.Test.Std10.MockItems
             ServerSendResponse = 5,
             ServerSendResponseNetwork,
             ClientSendResponseNetwork,
-            ClientSendResponse
+            ClientSendResponse,
+
+            ClientSendEmptyMessage = 10,
+            ClientSendEmptyMessageNetwork,
+            ServerSendEmptyMessageNetwork,
+            ServerSendEmptyMessage,
+
+            NetworkSend = 20
         }
 
         public QueueType ItemType { get; }
         public byte[] ItemData { get; }
-        public Request Request { get; }
-        public Response Response { get; }
+        public Request Request { get; set; }
+        public Response Response { get; set; }
+        public EmptyMessage EmptyMessage { get; set; }
         public Exchange Exchange { get; }
 
         public EndPoint Source { get; set; }
@@ -50,6 +64,13 @@ namespace CoAP.Test.Std10.MockItems
             ItemType = itemType;
             Response = response;
             Exchange = exchange;
+        }
+
+        public MockQueueItem(QueueType itemType, EmptyMessage request, Exchange exhange = null)
+        {
+            ItemType = itemType;
+            EmptyMessage = request;
+            Exchange = exhange;
         }
 
         /// <inheritdoc />

--- a/CoAP.Test/MockDriver/MockSession.cs
+++ b/CoAP.Test/MockDriver/MockSession.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Com.AugustCellars.CoAP;
 
-namespace CoAP.Test.Std10.MockItems
+namespace CoAP.Test.Std10.MockDriver
 {
     public class MockSession : ISession
     {

--- a/CoAP.Test/MockDriver/MockStack.cs
+++ b/CoAP.Test/MockDriver/MockStack.cs
@@ -1,13 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using CoAP.Test.Std10.OSCOAP;
 using Com.AugustCellars.CoAP;
 using Com.AugustCellars.CoAP.Codec;
 using Com.AugustCellars.CoAP.Net;
 using Com.AugustCellars.CoAP.Stack;
 
-namespace CoAP.Test.Std10.MockItems
+namespace CoAP.Test.Std10.MockDriver
 {
     public class MockStack : LayerStack
     {

--- a/CoAP.Test/Observe/ObserveTests.cs
+++ b/CoAP.Test/Observe/ObserveTests.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using Com.AugustCellars.CoAP;
 using Com.AugustCellars.CoAP.Log;

--- a/CoAP.Test/Observe/ObserveTests2.cs
+++ b/CoAP.Test/Observe/ObserveTests2.cs
@@ -1,0 +1,742 @@
+﻿/*
+ * Copyright (c) 2020, Jim Schaad <ietf@augustcellars.com>
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY.
+ * 
+ * This file is part of the CoAP.NET, a CoAP framework in C#.
+ * Please see README for more information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using CoAP.Test.Std10.MockDriver;
+using CoAP.Test.Std10.MockItems;
+using Com.AugustCellars.CoAP;
+using Com.AugustCellars.CoAP.Net;
+using Com.AugustCellars.CoAP.Server;
+using Com.AugustCellars.CoAP.Server.Resources;
+using Com.AugustCellars.CoAP.Stack;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoAP.Test.Std10.Observe
+{
+    [TestClass]
+    public class ObserveTests2
+    {
+        //  Test cases:
+        //  1. Normal observe 5 messages
+        //  2. Proactive unobserve
+        //  3. Reactive unobserve
+        //  4. Out of order notifications
+        //  5. End observe on an error
+        //  6. Rate limiting
+        //  7. CON with return from client
+        //  8. CON with no return from client
+        //  9. Client asks but server does not add to list
+        //  10. Client re-adds to list
+        //  11. Re-register based on time out
+        //  12. Cancel the re-registration
+        //  *. Re-registration cases
+        //  *. ETags in the request
+        //  *. Reset on unknown token - iff notification
+        //  *. Don't cancel if not same cache key
+        //  *. Weblinking - obs for /.well-known/core
+        //
+
+        [TestMethod]
+        public void ObserveTest1()
+        {
+            CoapConfig clientConfig = new CoapConfig();
+
+            Pump = new MockMessagePump();
+            
+            IEndPoint clientEndpoint = Pump.AddEndPoint("Client1", MockMessagePump.ClientAddress, clientConfig, new Type[] {typeof(ObserveLayer)});
+            clientEndpoint.Start();
+
+            CreateServer();
+
+            CoapClient coapClient = new CoapClient {
+                EndPoint = clientEndpoint, 
+                Uri = new Uri($"coap://{MockMessagePump.ServerAddress}{_resource.Uri}"), 
+                Timeout = 0
+            };
+
+            Response lastResponse = null;
+            int count = 1;
+            _resource.UpdateContent($"First string {count-1}");
+
+            AutoResetEvent trigger = new AutoResetEvent(false);
+            CoapObserveRelation relation = coapClient.ObserveAsync(
+                (r) => {
+                    lastResponse = r;
+                    trigger.Set();
+                });
+
+            byte[] tokenBytes = relation.Request.Token;
+            bool dataSent = false;
+            
+            while (true) {
+                Thread.Sleep(1);
+                if (Pump.Queue.Count > 0) {
+                    MockQueueItem item = Pump.Queue.Peek();
+                    switch (item.ItemType) {
+                    case MockQueueItem.QueueType.NetworkSend:
+                        if (item.Request != null) {
+                            if (tokenBytes == null) {
+                                tokenBytes = relation.Request.Token;
+                            }
+
+                            Assert.IsTrue(item.Request.HasOption(OptionType.Observe));
+                            Assert.AreEqual(0, item.Request.Observe);
+                            CollectionAssert.AreEqual(tokenBytes, item.Request.Token);
+                        }
+                        else if (item.Response != null) {
+                            Assert.IsTrue(item.Response.HasOption(OptionType.Observe));
+                            Assert.AreEqual(count, item.Response.Observe);
+                            CollectionAssert.AreEqual(tokenBytes, item.Response.Token);
+                            dataSent = true;
+                        }
+                        else {
+                            Assert.Fail();
+                        }
+
+                        break;
+                    }
+
+                    Pump.Pump();
+                }
+                else  if (dataSent) {
+                    Assert.IsTrue(trigger.WaitOne(1000));
+                    Assert.IsTrue(lastResponse.HasOption(OptionType.Observe));
+                    Assert.AreEqual(count, lastResponse.Observe);
+                    dataSent = false;
+                    lastResponse = null;
+
+                    if (count < 5) {
+                        _resource.UpdateContent($"New string {count}");
+                        count += 1;
+                    }
+                    else {
+                        break;
+                    }
+                }
+            }
+            Assert.AreEqual(5, count);
+        }
+
+        [TestMethod]
+        public void ObserveTest2()
+        {
+            CoapConfig clientConfig = new CoapConfig() {
+                NotificationReregistrationBackoff = 0
+            };
+
+            Pump = new MockMessagePump();
+
+            IEndPoint clientEndpoint = Pump.AddEndPoint("Client1", MockMessagePump.ClientAddress, clientConfig, new Type[] { typeof(ObserveLayer) });
+            clientEndpoint.Start();
+
+            CreateServer();
+
+            CoapClient coapClient = new CoapClient {
+                EndPoint = clientEndpoint,
+                Uri = new Uri($"coap://{MockMessagePump.ServerAddress}{_resource.Uri}"),
+                Timeout = 0
+            };
+
+            Response lastResponse = null;
+            int count = 1;
+            int clientObserveNo = 0;
+            _resource.UpdateContent($"First string {count - 1}");
+
+            AutoResetEvent trigger = new AutoResetEvent(false);
+            CoapObserveRelation relation = coapClient.ObserveAsync(
+                (r) => {
+                    lastResponse = r;
+                    trigger.Set();
+                });
+
+            AutoResetEvent reregistered = new AutoResetEvent(false);
+            relation.Request.Reregistering += (a, b) => {
+                reregistered.Set();
+            };
+
+            bool dataSent = false;
+            byte[] tokenBytes = relation.Request.Token;
+
+            while (true) {
+                Thread.Sleep(1);
+                if (Pump.Queue.Count > 0) {
+                    MockQueueItem item = Pump.Queue.Peek();
+                    switch (item.ItemType) {
+                    case MockQueueItem.QueueType.NetworkSend:
+                        if (item.Request != null) {
+                            if (tokenBytes == null) {
+                                tokenBytes = relation.Request.Token;
+                            }
+
+                            Assert.IsTrue(item.Request.HasOption(OptionType.Observe));
+                            Assert.AreEqual(clientObserveNo, item.Request.Observe);
+                            CollectionAssert.AreEqual(tokenBytes, item.Request.Token);
+                            clientObserveNo += 1;
+                        }
+                        else if (item.Response != null) {
+                            if (count < 4) {
+                                Assert.IsTrue(item.Response.HasOption(OptionType.Observe));
+                                Assert.AreEqual(count, item.Response.Observe);
+                            }
+                            else {
+                               // Assert.IsFalse(item.Response.HasOption(OptionType.Observe));
+                            }
+
+                            CollectionAssert.AreEqual(tokenBytes, item.Response.Token);
+                            dataSent = true;
+                        }
+                        else {
+                            Assert.Fail();
+                        }
+
+                        break;
+                    }
+
+                    Pump.Pump();
+                }
+                else if (dataSent) {
+                    dataSent = false;
+                    if (count > 4) {
+                        Assert.IsNull(lastResponse);
+                    }
+                    else {
+                        Assert.IsTrue(trigger.WaitOne(1000));
+                        Assert.IsNotNull(lastResponse);
+                        if (count == 4) {
+                            Assert.IsFalse(lastResponse.HasOption(OptionType.Observe));
+                        }
+                        else {
+                            Assert.IsTrue(lastResponse.HasOption(OptionType.Observe));
+                            Assert.AreEqual(count, lastResponse.Observe);
+                        }
+
+                        lastResponse = null;
+                    }
+
+                    if (count < 5) {
+                        if (count == 3) {
+                            relation.ProactiveCancel();
+                            _resource.UpdateContent($"New string {count}");
+                        }
+                        else {
+                            _resource.UpdateContent($"New string {count}");
+                        }
+                        count += 1;
+                    }
+                    else {
+                        break;
+                    }
+                }
+                else if (count == 5) {
+                    break;
+                }
+            }
+
+            Assert.AreEqual(2, clientObserveNo);
+            Assert.AreEqual(5, count);
+
+            //  Total # of seconds is MaxAge = 1 + backoff = 0 + random(2, 15) 
+            Assert.IsFalse(reregistered.WaitOne(17*1000));
+        }
+
+        [TestMethod]
+        public void ObserveTest3()
+        {
+            CoapConfig clientConfig = new CoapConfig();
+
+            Pump = new MockMessagePump();
+
+            IEndPoint clientEndpoint = Pump.AddEndPoint("Client1", MockMessagePump.ClientAddress, clientConfig, new Type[] { typeof(ObserveLayer) });
+            clientEndpoint.Start();
+
+            CreateServer();
+
+            CoapClient coapClient = new CoapClient {
+                EndPoint = clientEndpoint,
+                Uri = new Uri($"coap://{MockMessagePump.ServerAddress}{_resource.Uri}"),
+                Timeout = 0
+            };
+
+            Response lastResponse = null;
+            int count = 1;
+            _resource.UpdateContent($"First string {count - 1}");
+
+            AutoResetEvent trigger = new AutoResetEvent(false);
+            CoapObserveRelation relation = coapClient.ObserveAsync(
+                (r) => {
+                    lastResponse = r;
+                    trigger.Set();
+                });
+
+            int emptyCount = 0;
+            bool dataSent = false;
+            byte[] tokenBytes = relation.Request.Token;
+
+            while (true) {
+                Thread.Sleep(1);
+                if (Pump.Queue.Count > 0) {
+                    MockQueueItem item = Pump.Queue.Peek();
+                    switch (item.ItemType) {
+                        case MockQueueItem.QueueType.NetworkSend:
+                            if (item.Request != null) {
+                                if (tokenBytes == null) {
+                                    tokenBytes = relation.Request.Token;
+                                }
+
+                                Assert.IsTrue(item.Request.HasOption(OptionType.Observe));
+                                Assert.AreEqual(0, item.Request.Observe);
+                                CollectionAssert.AreEqual(tokenBytes, item.Request.Token);
+                            }
+                            else if (item.Response != null) {
+                                Assert.IsTrue(item.Response.HasOption(OptionType.Observe));
+                                Assert.AreEqual(count, item.Response.Observe);
+                                CollectionAssert.AreEqual(tokenBytes, item.Response.Token);
+                                dataSent = true;
+                            }
+                            else {
+                                emptyCount += 1;
+                            }
+
+                            break;
+                    }
+
+                    Pump.Pump();
+                }
+                else if (dataSent) {
+                    if (count >= 3) {
+                        Assert.IsNull(lastResponse);
+                    }
+                    else {
+                        Assert.IsTrue(trigger.WaitOne(1000));
+                        Assert.IsNotNull(lastResponse);
+                        Assert.IsTrue(lastResponse.HasOption(OptionType.Observe));
+                        Assert.AreEqual(count, lastResponse.Observe);
+                        lastResponse = null;
+                    }
+
+                    if (count < 5) {
+                        _resource.UpdateContent($"New string {count}");
+                        count += 1;
+                        if (count == 3) {
+                            relation.ReactiveCancel();
+                        }
+                    }
+                    else {
+                        break;
+                    }
+                }
+                else if (count == 5) {
+                    break;
+                }
+            }
+
+            Assert.AreEqual(3, emptyCount);
+            Assert.AreEqual(5, count);
+        }
+
+        [TestMethod]
+        public void ObserveTest11()
+        {
+            CoapConfig clientConfig = new CoapConfig() {
+                NotificationReregistrationBackoff = 0
+            };
+
+            Pump = new MockMessagePump();
+
+            IEndPoint clientEndpoint = Pump.AddEndPoint("Client1", MockMessagePump.ClientAddress, clientConfig, new Type[] { typeof(ObserveLayer) });
+            clientEndpoint.Start();
+
+            CreateServer();
+
+            CoapClient coapClient = new CoapClient
+            {
+                EndPoint = clientEndpoint,
+                Uri = new Uri($"coap://{MockMessagePump.ServerAddress}{_resource.Uri}"),
+                Timeout = 0
+            };
+
+            Response lastResponse = null;
+            int count = 1;
+            _resource.UpdateContent($"First string {count - 1}");
+
+            AutoResetEvent trigger = new AutoResetEvent(false);
+            CoapObserveRelation relation = coapClient.ObserveAsync(
+                (r) => {
+                    lastResponse = r;
+                    trigger.Set();
+                });
+
+            AutoResetEvent reregistered = new AutoResetEvent(false);
+            relation.Request.Reregistering += (a, b) => {
+                reregistered.Set();
+            };
+
+            byte[] tokenBytes = relation.Request.Token;
+            bool dataSent = false;
+
+            while (true) {
+                Thread.Sleep(1);
+                if (Pump.Queue.Count > 0) {
+                    MockQueueItem item = Pump.Queue.Peek();
+                    switch (item.ItemType) {
+                        case MockQueueItem.QueueType.NetworkSend:
+                            if (item.Request != null) {
+                                if (tokenBytes == null) {
+                                    tokenBytes = relation.Request.Token;
+                                }
+
+                                Assert.IsTrue(item.Request.HasOption(OptionType.Observe));
+                                Assert.AreEqual(0, item.Request.Observe);
+                                CollectionAssert.AreEqual(tokenBytes, item.Request.Token);
+                                Debug.WriteLine($"Request: ");
+                            }
+                            else if (item.Response != null) {
+                                Assert.IsTrue(item.Response.HasOption(OptionType.Observe));
+                                Assert.AreEqual(count > 4 ? count-1 : count, item.Response.Observe);
+                                CollectionAssert.AreEqual(tokenBytes, item.Response.Token);
+                                dataSent = true;
+                                Debug.WriteLine($"Response: {item.Response.Observe}");
+                            }
+                            else {
+                                Assert.Fail();
+                            }
+
+                            break;
+                    }
+
+                    Pump.Pump();
+                }
+                else if (dataSent) {
+                    Assert.IsTrue(trigger.WaitOne(1000));
+                    Assert.IsTrue(lastResponse.HasOption(OptionType.Observe));
+                    Assert.AreEqual(count > 4 ? count - 1 : count, lastResponse.Observe);
+                    dataSent = false;
+                    lastResponse = null;
+
+                    if (count == 4) {
+                        //  Sleep until it fires a re-registration
+                        Assert.IsTrue(reregistered.WaitOne(20*1000));
+                        count += 1;
+                    }
+                    else if (count < 8) {
+                        _resource.UpdateContent($"New string {count}");
+                        count += 1;
+                    }
+                    else {
+                        break;
+                    }
+                }
+            }
+            Assert.AreEqual(8, count);
+        }
+
+        [TestMethod]
+        public void ObserveTest12()
+        {
+            CoapConfig clientConfig = new CoapConfig()
+            {
+                NotificationReregistrationBackoff = 0
+            };
+
+            Pump = new MockMessagePump();
+
+            IEndPoint clientEndpoint = Pump.AddEndPoint("Client1", MockMessagePump.ClientAddress, clientConfig, new Type[] { typeof(ObserveLayer) });
+            clientEndpoint.Start();
+
+            CreateServer();
+
+            CoapClient coapClient = new CoapClient
+            {
+                EndPoint = clientEndpoint,
+                Uri = new Uri($"coap://{MockMessagePump.ServerAddress}{_resource.Uri}"),
+                Timeout = 0
+            };
+
+            Response lastResponse = null;
+            int count = 1;
+            _resource.UpdateContent($"First string {count - 1}");
+
+            AutoResetEvent trigger = new AutoResetEvent(false);
+            CoapObserveRelation relation = coapClient.ObserveAsync(
+                (r) => {
+                    lastResponse = r;
+                    trigger.Set();
+                });
+
+            AutoResetEvent reregistered = new AutoResetEvent(false);
+            relation.Request.Reregistering += (a, b) => {
+                reregistered.Set();
+                b.RefreshRequest.IsCancelled = true;
+            };
+
+            byte[] tokenBytes = relation.Request.Token;
+            bool dataSent = false;
+
+            while (true) {
+                Thread.Sleep(1);
+                if (Pump.Queue.Count > 0) {
+                    MockQueueItem item = Pump.Queue.Peek();
+                    switch (item.ItemType) {
+                        case MockQueueItem.QueueType.NetworkSend:
+                            if (item.Request != null) {
+                                if (tokenBytes == null) {
+                                    tokenBytes = relation.Request.Token;
+                                }
+
+                                Assert.IsTrue(item.Request.HasOption(OptionType.Observe));
+                                Assert.AreEqual(0, item.Request.Observe);
+                                CollectionAssert.AreEqual(tokenBytes, item.Request.Token);
+                                Debug.WriteLine($"Request: ");
+                            }
+                            else if (item.Response != null) {
+                                Assert.IsTrue(item.Response.HasOption(OptionType.Observe));
+                                Assert.AreEqual(count > 4 ? count - 1 : count, item.Response.Observe);
+                                CollectionAssert.AreEqual(tokenBytes, item.Response.Token);
+                                dataSent = true;
+                                Debug.WriteLine($"Response: {item.Response.Observe}");
+                            }
+                            else {
+                                Assert.Fail();
+                            }
+
+                            break;
+                    }
+
+                    Pump.Pump();
+                }
+                else if (dataSent) {
+                    Assert.IsTrue(trigger.WaitOne(1000));
+                    Assert.IsTrue(lastResponse.HasOption(OptionType.Observe));
+                    Assert.AreEqual(count > 4 ? count - 1 : count, lastResponse.Observe);
+                    dataSent = false;
+                    lastResponse = null;
+
+                    if (count == 4) {
+                        //  Sleep until it fires a re-registration
+                        Assert.IsTrue(reregistered.WaitOne(20 * 1000));
+                        count += 1;
+                        Assert.IsTrue(Pump.Queue.Count == 0);
+                        break;
+                    }
+                    else if (count < 8) {
+                        _resource.UpdateContent($"New string {count}");
+                        count += 1;
+                    }
+                    else {
+                        break;
+                    }
+                }
+            }
+            Assert.AreEqual(5, count);
+        }
+
+        [TestMethod]
+        public void ObserveTest13()
+        {
+            CoapConfig clientConfig = new CoapConfig()
+            {
+                NotificationReregistrationBackoff = 0
+            };
+
+            Pump = new MockMessagePump();
+
+            IEndPoint clientEndpoint = Pump.AddEndPoint("Client1", MockMessagePump.ClientAddress, clientConfig, new Type[] { typeof(ObserveLayer) });
+            clientEndpoint.Start();
+
+            CreateServer();
+
+            CoapClient coapClient = new CoapClient
+            {
+                EndPoint = clientEndpoint,
+                Uri = new Uri($"coap://{MockMessagePump.ServerAddress}{_resource.Uri}"),
+                Timeout = 0
+            };
+
+            Response lastResponse = null;
+            int count = 1;
+            _resource.UpdateContent($"First string {count - 1}");
+
+            AutoResetEvent trigger = new AutoResetEvent(false);
+            CoapObserveRelation relation = coapClient.ObserveAsync(
+                (r) => {
+                    lastResponse = r;
+                    trigger.Set();
+                });
+
+            AutoResetEvent reregistered = new AutoResetEvent(false);
+            relation.Request.Reregistering += (a, b) => {
+                reregistered.Set();
+                b.RefreshRequest.IsCancelled = true;
+            };
+
+
+            byte[] tokenBytes = relation.Request.Token;
+            bool dataSent = false;
+            int requestNo = 0;
+            int observerNo = 1;
+
+            while (true) {
+                Thread.Sleep(1);
+                if (Pump.Queue.Count > 0) {
+                    MockQueueItem item = Pump.Queue.Peek();
+                    switch (item.ItemType) {
+                        case MockQueueItem.QueueType.NetworkSend:
+                            if (item.Request != null) {
+                                if (tokenBytes == null) {
+                                    tokenBytes = relation.Request.Token;
+                                }
+
+                                Assert.IsTrue(item.Request.HasOption(OptionType.Observe));
+                                Assert.AreEqual(0, item.Request.Observe);
+                                CollectionAssert.AreEqual(tokenBytes, item.Request.Token);
+
+                                switch (requestNo) {
+                                    case 0:
+                                        Assert.IsFalse(item.Request.HasOption(OptionType.ETag));
+                                        break;
+
+                                    case 1:
+                                    case 2:
+                                        Assert.AreEqual(4, item.Request.ETags.ToArray().Length);
+                                        break;
+                                }
+
+                                requestNo += 1;
+                                Debug.WriteLine($"Request: {item.Request}");
+                            }
+                            else if (item.Response != null) {
+                                Assert.IsTrue(item.Response.HasOption(OptionType.Observe));
+                                Assert.AreEqual(observerNo, item.Response.Observe);
+                                CollectionAssert.AreEqual(tokenBytes, item.Response.Token);
+                                dataSent = true;
+                                Debug.WriteLine($"Response: {item.Response} {item.Response.Observe}");
+                            }
+                            else {
+                                Assert.Fail();
+                            }
+
+                            break;
+                    }
+
+                    Pump.Pump();
+                }
+                else if (dataSent) {
+                    Assert.IsTrue(trigger.WaitOne(1000));
+                    Assert.IsTrue(lastResponse.HasOption(OptionType.Observe));
+                    Assert.AreEqual(observerNo, lastResponse.Observe);
+                    dataSent = false;
+                    lastResponse = null;
+
+                    if (count == 4) {
+                        relation.UpdateETags(new byte[][]{new byte[]{1}, new byte[]{3}, new byte[]{5}, new byte[]{7}});
+                        count += 1;
+                    }
+                    else if (count == 8) {
+                        Assert.IsTrue(reregistered.WaitOne(20*1000));
+                        count += 1;
+                    }
+
+                    if (count == 9) {
+                        count += 1;
+                        _resource.UpdateContent($"New string {count}");
+                        observerNo += 1;
+                        count += 1;
+                    }
+                    else if (count < 12) {
+                        _resource.UpdateContent($"New string {count}");
+                        count += 1;
+                        observerNo += 1;
+                    }
+                    else {
+                        break;
+                    }
+                }
+            }
+            Assert.AreEqual(12, count);
+        }
+
+        private CoapConfig _config;
+        private ObserveResource _resource;
+        private ObserveResource _resource2;
+        private CoapServer _server;
+
+        private const string target1 = "Resource1";
+        private const string target2 = "Resource2";
+
+        private MockMessagePump Pump { get; set; }
+
+        private void CreateServer()
+        {
+            _config = new CoapConfig {
+                NonTimeout = 10             // 10 ms
+            };
+
+            _resource = new ObserveTests2.ObserveResource(target1);
+            _resource2 = new ObserveTests2.ObserveResource(target2);
+            _server = new CoapServer(_config);
+            _server.Add(_resource);
+            _server.Add(_resource2);
+            IEndPoint endpoint = Pump.AddEndPoint("server #1", MockMessagePump.ServerAddress, _config, new Type[] { typeof(ObserveLayer), typeof(TokenLayer), typeof(ReliabilityLayer) });
+
+            _server.AddEndPoint(endpoint);
+            _server.Start();
+
+        }
+
+        class ObserveResource : Resource
+        {
+            private string _content = "No Content Yet";
+            public int ObserveNo { get; set; }
+
+            public ObserveResource(string name)
+                : base(name)
+            {
+                Observable = true;
+            }
+
+            protected override void DoGet(CoapExchange exchange)
+            {
+                IEnumerable<string> queries = exchange.Request.UriQueries;
+
+                exchange.MaxAge = 1;
+                exchange.Respond(_content);
+            }
+
+            protected override void DoPost(CoapExchange exchange)
+            {
+                string old = _content;
+                _content = exchange.Request.PayloadString;
+                exchange.Respond(StatusCode.Changed, old);
+                Changed();
+            }
+
+            public void Canceled(bool notify)
+            {
+                if (notify) {
+                    ClearAndNotifyObserveRelations(StatusCode.BadRequest);
+                }
+                else {
+                    ClearObserveRelations();
+                }
+            }
+
+            public void UpdateContent(string text)
+            {
+                _content = text;
+                Changed();
+            }
+        }
+    }
+}
+

--- a/CoAP.Test/Stack/BlockwiseTest.cs
+++ b/CoAP.Test/Stack/BlockwiseTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using CoAP.Test.Std10.MockDriver;
 using CoAP.Test.Std10.MockItems;
 using Com.AugustCellars.CoAP;
 using Com.AugustCellars.CoAP.Net;

--- a/CoAP.Test/Stack/BlockwiseTest.cs
+++ b/CoAP.Test/Stack/BlockwiseTest.cs
@@ -172,7 +172,6 @@ namespace CoAP.Test.Std10.Stack
                     else {
                         Assert.Fail();
                     }
-
                     break;
                 }
             }


### PR DESCRIPTION
* Also put in some more code dealing with unit tests and put in a small set of observe tests
* Move the observe counter back to private non-static so that the tests are happy.  There was no specific comment why I changed this to start with.
* Move reconnect and cancel variables for observe into the observe relation structure
* Add ability to update the etags on an observe relationship
* Allow for observe to be canceled when doing a reconnect.
* Change the message pump so that the full stack with a Mock Channel can be used.  Just changes the network into the message pump.