### PR TITLE
Fixed potential denial of service attack in DTLS server

### DIFF
--- a/CoAP.NET/CoAP.Std10.csproj
+++ b/CoAP.NET/CoAP.Std10.csproj
@@ -266,6 +266,7 @@ It is intented primarily for research and verification work.
   
   <ItemGroup>
     <PackageReference Include="Com.AugustCellars.COSE" Version="1.6.0" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.10" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.0" />

--- a/CoAP.NET/DTLS/DtlsServer.cs
+++ b/CoAP.NET/DTLS/DtlsServer.cs
@@ -41,6 +41,11 @@ namespace Com.AugustCellars.CoAP.DTLS
         public OneKey AuthenticationKey => mPskIdentityManager.AuthenticationKey;
         public Certificate AuthenticationCertificate { get; private set; }
 
+        public override int GetHandshakeTimeoutMillis()
+        {
+            return 60000; // 60 seconds
+        }
+
         // Chain all of our events to the next level up.
 
         private void OnTlsEvent(Object o, TlsEvent e)

--- a/CoAP.Test/CoAP.Test.Std10.csproj
+++ b/CoAP.Test/CoAP.Test.Std10.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
     <PackageReference Include="PeterO.Cbor" Version="4.0.1" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.10" />
     <PackageReference Include="Com.AugustCellars.COSE" Version="1.6.0" />
   </ItemGroup>
 


### PR DESCRIPTION
by implementing handshake timeout (requires to upgrade to the latest version of Bouncy Castle)