### PR TITLE
Fire responding event for a request while transmitting a large post with block1 option.

### DIFF
--- a/CoAP.Example/CoAP.Client/ExampleClient.cs
+++ b/CoAP.Example/CoAP.Client/ExampleClient.cs
@@ -145,6 +145,18 @@ namespace Com.AugustCellars.CoAP.Examples
             {
                 if (byEvent)
                 {
+                    request.Responding += (Object sender, ResponseEventArgs e) =>
+                    {
+                        Response response = e.Response;
+                        if (response != null)
+                        {
+                            //Console.WriteLine(Utils.ToString(response));
+                            if (response.Block1 != null)
+                                Console.WriteLine($"Responding Time (ms): {response.RTT},BLOCK1--> NUM:{response.Block1.NUM}, MORE:{response.Block1.M}, SZX:{response.Block1.SZX}");
+                            if (response.Block2 != null)
+                                Console.WriteLine($"Responding Time (ms): {response.RTT},BLOCK2--> NUM:{response.Block2.NUM}, MORE:{response.Block2.M}, SZX:{response.Block2.SZX}");
+                        }
+                    };
                     request.Respond += delegate(Object sender, ResponseEventArgs e)
                     {
                         Response response = e.Response;

--- a/CoAP.Example/CoAP.Server/Resources/LargeResource.cs
+++ b/CoAP.Example/CoAP.Server/Resources/LargeResource.cs
@@ -10,7 +10,12 @@ namespace Com.AugustCellars.CoAP.Examples.Resources
 
         static LargeResource()
         {
-            payload = new StringBuilder()
+            payload = getDefaultPayload();
+        }
+
+        protected static string getDefaultPayload()
+        { 
+            return new StringBuilder()
                 .Append("/-------------------------------------------------------------\\\r\n")
                 .Append("|                 RESOURCE BLOCK NO. 1 OF 8                   |\r\n")
                 .Append("|               [each line contains 64 bytes]                 |\r\n")
@@ -60,12 +65,21 @@ namespace Com.AugustCellars.CoAP.Examples.Resources
 
         protected override void DoPost(CoAP.Server.Resources.CoapExchange exchange)
         {
-            exchange.Respond(payload);
+            //exchange.Respond(payload);
+            payload = exchange.Request.PayloadString;
+            exchange.Respond(StatusCode.Changed);
         }
 
         protected override void DoPut(CoAP.Server.Resources.CoapExchange exchange)
         {
-            exchange.Respond(payload);
+            //exchange.Respond(payload);
+            payload = exchange.Request.PayloadString;
+            exchange.Respond(StatusCode.Created);
+        }
+        protected override void DoDelete(CoapExchange exchange)
+        {
+            payload = getDefaultPayload();
+            exchange.Respond(StatusCode.Deleted);
         }
     }
 }

--- a/CoAP.NET/OSCOAP/SecureBlockwiseLayer.cs
+++ b/CoAP.NET/OSCOAP/SecureBlockwiseLayer.cs
@@ -328,6 +328,9 @@ namespace Com.AugustCellars.CoAP.OSCOAP
                         nextBlock.Token = response.Token; // reuse same token
                     }
 
+                    // notify blocking progress
+                    exchange.Request.FireResponding(response);
+
                     exchange.CurrentRequest = nextBlock;
                     log.Debug(m => m($"ReceiveResponse: Block message to send: {nextBlock}"));
                     base.SendRequest(nextLayer, exchange, nextBlock);

--- a/CoAP.NET/Stack/BlockwiseLayer.cs
+++ b/CoAP.NET/Stack/BlockwiseLayer.cs
@@ -307,7 +307,10 @@ namespace Com.AugustCellars.CoAP.Stack
                     }
 
                     nextBlock.RemoveOptions(OptionType.Observe);
-                    
+
+                    // notify blocking progress
+                    exchange.Request.FireResponding(response);
+
                     exchange.CurrentRequest = nextBlock;
                     base.SendRequest(nextLayer, exchange, nextBlock);
                     // do not deliver response


### PR DESCRIPTION
For a large GET with several block2, there is a Responding Event for every bloc exchange (each response block from the server).
I need to have the same approach for a large POST with Block1 specified : (each response block from the server too).
This way it is more effective to manage timeouts from the client that can reset the timeout as far as the server is responding ! (instead of having extra long timeout...).
What I have changed is :
- Fire responding event for a request while transmitting a large post with block1 option if file Stack\BlockwiseLayer.cs and OSCOAP\SecureBlockwiseLayer.cs --> Please have look here to check if its the best place.
- Modify ExampleClient and ExampleServer for testing.
